### PR TITLE
feat: support startup commands as env vars

### DIFF
--- a/scripts/jenkins-jnlp-agent/jenkins-agent
+++ b/scripts/jenkins-jnlp-agent/jenkins-agent
@@ -27,6 +27,12 @@
 # * JENKINS_TUNNEL : HOST:PORT for a tunnel to route TCP traffic to jenkins host, when jenkins can't be directly accessed over network
 # * JENKINS_URL : alternate jenkins URL
 
+# Allows for running extra startup commands
+if [[ -n "${STARTUP_COMMANDS}" ]]; then
+	echo "Running extra startup commands...."
+	bash -c "${STARTUP_COMMANDS}"
+fi
+
 if [[ $# -eq 1 ]]; then
 
 	# if `docker run` only has one arguments, we assume user is running alternate command like `bash` to inspect the image


### PR DESCRIPTION
allows for short env var based scripts to be run before the jnlp agent is started. This allows for on boot configuration for git or other tools