### PR TITLE
Fix - Azure CLI Extensions Directory

### DIFF
--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -106,8 +106,11 @@ RUN pip install --upgrade --no-cache-dir \
         coverage \
         flake8
 
-# Install Azure CLI Extensions
+# Install Azure CLI Extensions (default location is in $HOME)
+ENV AZURE_EXTENSION_DIR=/opt/azcliextensions
+RUN mkdir /opt/azcliextensions
 RUN az extension add --name front-door
+RUN chmod 0755 --recursive /opt/azcliextensions
 
 # rbenv requirements
 ENV RUBY_VERSION 2.5.1


### PR DESCRIPTION
# Description 
Move the Azure CLI Extensions directory somewhere available to all accounts.

# Motivation
Extensions were not accessible to the `hamlet` user when another image is built from this. The `root` user installs the extension so the extension which defaults to $HOME/.azure/... - setting the global variable AZURE_EXTENSION_DIR overrides this.