### PR TITLE
Feature - Include Diagrams Plugin

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,6 +27,10 @@
         {
             "Repository" : "https://github.com/hamlet-io/engine-plugin-aws.git",
             "Directory" : "/opt/hamlet/engine/plugins/aws"
+        },
+        {
+            "Repository" : "https://github.com/hamlet-io/engine-plugin-diagrams.git",
+            "Directory" : "/opt/hamlet/engine/plugins/diagrams"
         }
     ]
 }

--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -18,7 +18,7 @@ ENV AUTOMATION_BASE_DIR=/opt/hamlet/executor/automation \
         GENERATION_BASE_DIR=/opt/hamlet/executor \
         GENERATION_DIR=/opt/hamlet/executor/cli \
         GENERATION_ENGINE_DIR=/opt/hamlet/engine/core \
-        GENERATION_PLUGIN_DIRS=/opt/hamlet/engine/plugins/aws;/opt/hamlet/engine/plugins/azure \
+        GENERATION_PLUGIN_DIRS=/opt/hamlet/engine/plugins/aws;/opt/hamlet/engine/plugins/azure;/opt/hamlet/engine/plugins/diagrams \
         GENERATION_STARTUP_DIR=/opt/hamlet/startup \
         GENERATION_PATTERNS_DIR=/opt/hamlet/patterns
 

--- a/scripts/base/build_hamlet.sh
+++ b/scripts/base/build_hamlet.sh
@@ -7,7 +7,11 @@ if [[ "${HAMLET_VERSION}" == "latest" ]]; then
 fi
 
 # Create the Git clone commands to get the Repositories
-jq  -r '.Repositories[] | "git clone --depth 1 --branch \(env.HAMLET_VERSION) \(.Repository) \(.Directory)" ' </build/config.json > /build/scripts/clone.sh
+# note: original hamlet-io repositories use "master" as default branch
+#       whilst the modern approach is to use "main" as default.
+#       This checks for the existence of the HAMLET_VERSION branch and
+#       if it does not exist, it attempts "main" instead.
+jq -r '.Repositories[] | "git ls-remote --heads \(.Repository) \(env.HAMLET_VERSION) && git clone --depth 1 --branch \(env.HAMLET_VERSION) \(.Repository) \(.Directory) || git ls-remote --heads \(.Repository) main && git clone --depth 1 --branch main \(.Repository) \(.Directory)" ' </build/config.json > /build/scripts/clone.sh
 chmod u+rwx /build/scripts/clone.sh
 
 # Create the Version file from the config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Load the `diagrams` plugin into the Hamlet Deploy Engine as a standard feature
- When cloning remote repositories, allow for a "default" branch of `master` or `main`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
hamlet-io/executor-python#75

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
local container build and check env var + plugin dir are as expected

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions
<!---
    Are the changes mandatory (breaking) or optional?
    What changes must a consumer of this repository make in order to utilise it?
    Are there other issues or steps that need to happen once this PR is merged?

    Add a checklist of items or leave the default of "None"
-->
- [x] None