### PR TITLE
fix: handle git refs during build process

### DIFF
--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -174,8 +174,7 @@ RUN mv /build/scripts/entrypoint.sh /entrypoint.sh && \
         chmod ugo+rx /entrypoint.sh
 
 RUN echo "Cloning images on $(date +%s)" && \
-	/build/scripts/build_hamlet.sh && \
-        /build/scripts/clone.sh
+	/build/scripts/build_hamlet.sh
 
 # Install the hamlet cli
 WORKDIR /opt/hamlet/cli/hamlet-cli


### PR DESCRIPTION
## Description

Update the clone configuration for hamlet build to handle tags, and main master branches for builds

## Motivation and Context

Cloning of the hamlet repos were failing when using a version tag 

## How Has This Been Tested?

Tested locally 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
