### PR TITLE
refactor: remove startup script repo

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,10 +9,6 @@
             "Directory" : "/opt/hamlet/executor"
         },
         {
-            "Repository" : "https://github.com/hamlet-io/cloudinit-aws.git",
-            "Directory" : "/opt/hamlet/startup"
-        },
-        {
             "Repository" : "https://github.com/hamlet-io/executor-cookiecutter.git",
             "Directory" : "/opt/hamlet/patterns"
         },

--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -19,7 +19,6 @@ ENV AUTOMATION_BASE_DIR=/opt/hamlet/executor/automation \
         GENERATION_DIR=/opt/hamlet/executor/cli \
         GENERATION_ENGINE_DIR=/opt/hamlet/engine/core \
         GENERATION_PLUGIN_DIRS=/opt/hamlet/engine/plugins/aws;/opt/hamlet/engine/plugins/azure;/opt/hamlet/engine/plugins/diagrams \
-        GENERATION_STARTUP_DIR=/opt/hamlet/startup \
         GENERATION_PATTERNS_DIR=/opt/hamlet/patterns
 
 # Install OS Packages


### PR DESCRIPTION
## Description

Removes the startup script repo from hamlet docker image as it has now been deprecated 

## Motivation and Context

Moves the startup functionality into the engine and allows for more flexible control over how scripts are handled

## How Has This Been Tested?

Tested locally 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (non-breaking change which improves the structure or operation of the implementation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Followup Actions

- [x] None

## Checklist:

- [ ] My change requires a change to the [documentation](https://github.com/hamlet-io/docs).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] None of the above.
