### PR TITLE
feat: include cmdb plugin

### DIFF
--- a/config.json
+++ b/config.json
@@ -27,6 +27,10 @@
         {
             "Repository" : "https://github.com/hamlet-io/engine-plugin-diagrams.git",
             "Directory" : "/opt/hamlet/engine/plugins/diagrams"
+        },
+        {
+            "Repository" : "https://github.com/hamlet-io/engine-plugin-cmdb.git",
+            "Directory" : "/opt/hamlet/engine/plugins/cmdb"
         }
     ]
 }


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Include the cmdb plugin in the image.


## Motivation and Context
By including the cmdb plugin, it makes continued testing of its use easier given the auto-detection logic in the bash executor.

Note that because the cmdb plugin is not currently included in the `GENERATION_PLUGIN_DIRS` environment variable, dynamic cmdb processing won't be active by default, but simply by adding it as an extra path value to this variable, dynamic cmdb loading will be activated.

## How Has This Been Tested?
It hasn't - simple enough that any issues will be fixed following any issues in container build pipeline.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

