### PR TITLE
refactor: install hamlet-cli via pip

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,10 +1,6 @@
 {
     "Repositories" :[
         {
-            "Repository" : "https://github.com/hamlet-io/executor-python.git",
-            "Directory" : "/opt/hamlet/cli"
-        },
-        {
             "Repository" : "https://github.com/hamlet-io/executor-bash.git",
             "Directory" : "/opt/hamlet/executor"
         },

--- a/images/stretch/Dockerfile
+++ b/images/stretch/Dockerfile
@@ -175,10 +175,6 @@ RUN mv /build/scripts/entrypoint.sh /entrypoint.sh && \
 RUN echo "Cloning images on $(date +%s)" && \
 	/build/scripts/build_hamlet.sh
 
-# Install the hamlet cli
-WORKDIR /opt/hamlet/cli/hamlet-cli
-RUN pip install /opt/hamlet/cli/hamlet-cli
-
 WORKDIR /root
 
 ENTRYPOINT [ "/entrypoint.sh" ]

--- a/scripts/base/build_hamlet.sh
+++ b/scripts/base/build_hamlet.sh
@@ -37,5 +37,12 @@ chmod u+rwx /build/scripts/clone.sh
 
 . /build/scripts/clone.sh
 
+# Use pypi to install the cli
+if [[ "${HAMLET_VERSION}" == "latest" ]];
+    pip install --pre hamlet-cli
+else
+    pip install "hamlet-cli=${HAMLET_VERSION}"
+fi
+
 # Create the Version file from the config
 echo "{}" | jq  '{ "FrameworkVersion" : env.HAMLET_VERSION, "ContainerVersion" : env.DOCKER_IMAGE_VERSION  }' > /opt/hamlet/version.json

--- a/scripts/base/build_hamlet.sh
+++ b/scripts/base/build_hamlet.sh
@@ -38,7 +38,7 @@ chmod u+rwx /build/scripts/clone.sh
 . /build/scripts/clone.sh
 
 # Use pypi to install the cli
-if [[ "${HAMLET_VERSION}" == "latest" ]];
+if [[ "${HAMLET_VERSION}" == "latest" ]]; then
     pip install --pre hamlet-cli
 else
     pip install "hamlet-cli=${HAMLET_VERSION}"


### PR DESCRIPTION
## Intent of Change

- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description

Updates the hamlet install process to use pip for the hamlet-cli instead of cloning and installing from the repo

## Motivation and Context

This uses the deployment process we have now automated for the cli and aligns with best practice for python 

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

