### PR TITLE
fix: include plugins for global node packages

### DIFF
--- a/scripts/user_env/0_nodenv.sh
+++ b/scripts/user_env/0_nodenv.sh
@@ -3,11 +3,18 @@ set -eo pipefail
 
 NODENV_ROOT="${NODENV_ROOT:-"${HOME}/.nodenv"}"
 
+# Base nodenv and a couple of plugins to handle global packages and manage installations
 git clone --depth 1 https://github.com/nodenv/nodenv.git "${NODENV_ROOT}"
 git clone --depth 1 https://github.com/nodenv/node-build.git "${NODENV_ROOT}/plugins/node-build"
 git clone --depth 1 https://github.com/nodenv/node-build-update-defs.git "${NODENV_ROOT}/plugins/node-build-update-defs"
+git clone --depth 1 https://github.com/nodenv/nodenv-package-rehash.git "${NODENV_ROOT}/plugins/nodenv-package-rehash"
+git clone --depth 1 https://github.com/nodenv/nodenv-default-packages.git "${NODENV_ROOT}/plugins/nodenv-default-packages"
 
 ( cd ${NODENV_ROOT} && src/configure && make -C src )
+
+# install package managers in all nodenv versions
+echo "npm" >> "${NODENV_ROOT}/default-packages"
+echo "yarn" >> "${NODENV_ROOT}/default-packages"
 
 # nodenv install
 NODE_VERSION=12.22.1
@@ -15,3 +22,5 @@ eval "$(nodenv init -)"
 nodenv install "${NODE_VERSION}"
 nodenv global "${NODE_VERSION}"
 node --version
+
+nodenv package-hooks install --all


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Description

- Add nodenv plugins which handle the shim processing for global node packges. This adds a hook in npm which tells nodenv to update the available binaries on global installs
- Adds yarn and npm ( update ) as default packages for all node versions installed. This will be automatically done as part of the install process

## Motivation and Context

Yarn should be a default package available under all installations since it is used to install and setup any app

## How Has This Been Tested?

Tested locally 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

