### PR TITLE
fix: remove docker layer caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,14 +74,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -95,10 +87,3 @@ jobs:
           push: ${{ startsWith(steps.get_tag_name.outputs.PUSH_IMAGE, 'true') }}
           tags: hamletio/hamlet:${{ steps.get_tag_name.outputs.TAG_PREFIX }}${{ matrix.image_tag }}
           target: ${{ matrix.docker_target }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Remove caching for the docker build process

## Motivation and Context

Docker caching only works if file contents change as part of the image and aren't affected by changes created by scripts.

Since this image is based on tool installs we should always rebuild the image without a cache. The image isn't built too often now so it won't really be an impact


## How Has This Been Tested?

Tested using workflow

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

