### PR TITLE
fix: set default engine to tram

### DIFF
--- a/scripts/user_env/3_setup_hamlet.sh
+++ b/scripts/user_env/3_setup_hamlet.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-HAMLET_ENGINE="${HAMLET_ENGINE:-"unicycle"}"
+HAMLET_ENGINE="${HAMLET_ENGINE:-"tram"}"
 
 # make sure the config dir exists for volume mounts
 mkdir -p "${HOME}/.hamlet/config"


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Set the default hamlet engine to the tram release instead of unicycle

## Motivation and Context

The tram release is nightly build of the hamlet engine which has been tested across a more stringent process than the unicycle engine which gets the latest updates from each individual source. 

This makes the hamlet container more friendly to new users and use in CI environments

## How Has This Been Tested?

Tested locally

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

