### PR TITLE
feat: add smoke tests for hamlet engine setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -212,13 +212,13 @@ ENV PATH=$HOME/.pyenv/bin:$HOME/.pyenv/versions:$HOME/.pyenv/shims:$PATH
 ENV PATH=$HOME/.rbenv/bin:$HOME/.rbenv/versions:$HOME/.rbenv/shims:$PATH
 ENV PYENV_ROOT=$HOME/.pyenv NODENV_ROOT=$HOME/.nodenv RBENV_ROOT=$HOME/.rbenv
 
-ENV GENERATION_ENGINE_DIR=$HOME/.hamlet/engine/engines/_global/shim/engine-core \
-        GENERATION_PLUGIN_DIRS=$HOME/.hamlet/engine/engines/_global/shim/engine-plugin-aws;$HOME/.hamlet/engine/engines/_global/shim/engine-plugin-azure \
-        GENERATION_BIN_DIR=$HOME/.hamlet/engine/engines/_global/shim/engine-binary \
-        GENERATION_BASE_DIR=$HOME/.hamlet/engine/engines/_global/shim/executor-bash \
-        GENERATION_DIR=$HOME/.hamlet/engine/engines/_global/shim/executor-bash/cli \
-        AUTOMATION_DIR=$HOME/.hamlet/engine/engines/_global/shim/executor-bash/automation/jenkins/aws \
-        AUTOMATION_BASE_DIR=$HOME/.hamlet/engine/engines/_global/shim/executor-bash/automation
+ENV GENERATION_ENGINE_DIR="$HOME/.hamlet/engine/engines/_global/shim/engine-core" \
+        GENERATION_PLUGIN_DIRS="$HOME/.hamlet/engine/engines/_global/shim/engine-plugin-aws;$HOME/.hamlet/engine/engines/_global/shim/engine-plugin-azure" \
+        GENERATION_BIN_DIR="$HOME/.hamlet/engine/engines/_global/shim/engine-binary" \
+        GENERATION_BASE_DIR="$HOME/.hamlet/engine/engines/_global/shim/executor-bash" \
+        GENERATION_DIR="$HOME/.hamlet/engine/engines/_global/shim/executor-bash/cli" \
+        AUTOMATION_DIR="$HOME/.hamlet/engine/engines/_global/shim/executor-bash/automation/jenkins/aws"\
+        AUTOMATION_BASE_DIR="$HOME/.hamlet/engine/engines/_global/shim/executor-bash/automation"
 
 ## Setup the user specific tooling
 RUN /opt/tools/scripts/setup_user_env.sh

--- a/scripts/user_env/3_setup_hamlet.sh
+++ b/scripts/user_env/3_setup_hamlet.sh
@@ -6,6 +6,12 @@ HAMLET_ENGINE="${HAMLET_ENGINE:-"tram"}"
 # make sure the config dir exists for volume mounts
 mkdir -p "${HOME}/.hamlet/config"
 
+# Install and set a default hamlet engine so that things work out of the box
 pip install --pre hamlet-cli
-hamlet engine install-engine ${HAMLET_ENGINE}
-hamlet engine set-engine ${HAMLET_ENGINE}
+hamlet engine install-engine "${HAMLET_ENGINE}"
+hamlet engine set-engine "${HAMLET_ENGINE}"
+
+# Basic smoke tests to ensure global engine is working
+[[ "$(hamlet engine env GENERATION_DIR)" == "${GENERATION_DIR}" ]] || ( echo "GENERATION_DIR environment variable doesn't match cli expected variable"; exit 255 )
+[[ -d "$(hamlet engine env GENERATION_DIR)" ]] || ( echo "No global engine dir found"; exit 255 )
+[[ "$(ls -A $(hamlet engine env GENERATION_DIR)))" ]] || ( echo "Global engine dir empty"; exit 255 )


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Adds some basic smoke tests to make sure that hamlet has been installed as expected and that it is available for the container to use

## Motivation and Context

We want to make sure basic things like the hamlet engine are available 

This was discovered as an issue in https://github.com/hamlet-io/executor-python/issues/177 

## How Has This Been Tested?

Tested locally 

## Related Changes

None

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

