### PR TITLE
fix(ci): create draft PR for changelog generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -31,9 +31,13 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
-          commit-message: "chore: changelog bump [skip actions]"
+          commit-message: "chore: changelog bump"
           delete-branch: true
           title: 'chore: update changelog'
-          body: 'Updates the changelog with the latest updates'
+          body: |
+            Updates the changelog with the latest updates
+            This is raised as a draft and should be merged on the creation of a new release
           labels: 'chore'
           base: 'master'
+          branch: create-pull-request/changelog_bump
+          draft: true


### PR DESCRIPTION
## Intent of Change

- Bug fix (non-breaking change which fixes an issue)

## Description

Create a draft PR for changelog updates and enable CI to ensure that the changelog can be merged as required

## Motivation and Context

Makes it easy to follow the changelog setup and removes some of the confusion around changelog generation

## How Has This Been Tested?

Tested on all other repos 

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

