### PR TITLE
feat: default to unicycle builds on schedules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
   # Run a weekly update to get the latest packages
   workflow_dispatch:
   schedule:
-    - cron: 0 7 * * 0
+    - cron: 0 9 * * *
 
 jobs:
 
@@ -54,7 +54,7 @@ jobs:
           tags: |
             type=edge,branch=master
             type=semver,pattern={{version}}
-            type=schedule,pattern=weekly
+            type=schedule,pattern=nightly
             type=schedule,pattern=schedule-{{date 'YYYYMMDD'}}
             type=sha
 
@@ -67,6 +67,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Hamlet engine
+        id: hamlet_engine
+        run: |
+          # Used to create a docker image which runs on the unicycle by default
+          # run each night and contains the latest engine and docker updates
+
+          if [[ "${{ github.event_name == 'scheduled' }}" == "true" ]]; then
+            echo ::set-env name=HAMLET_ENGINE::"unicycle"
+          else
+            echo ::set-env name=HAMLET_ENGINE::""
+          fi
+
       - name: Push Release
         uses: docker/build-push-action@v2
         with:
@@ -74,3 +86,5 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           target: ${{ matrix.docker_target }}
+          build-args: |
+            HAMLET_ENGINE=${{ steps.hamlet_engine.outputs.HAMLET_ENGINE }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,9 +74,9 @@ jobs:
           # run each night and contains the latest engine and docker updates
 
           if [[ "${{ github.event_name == 'scheduled' }}" == "true" ]]; then
-            echo ::set-env name=HAMLET_ENGINE::"unicycle"
+            echo ::set-output name=HAMLET_ENGINE::"unicycle"
           else
-            echo ::set-env name=HAMLET_ENGINE::""
+            echo ::set-output name=HAMLET_ENGINE::""
           fi
 
       - name: Push Release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,11 +73,17 @@ jobs:
           # Used to create a docker image which runs on the unicycle by default
           # run each night and contains the latest engine and docker updates
 
-          if [[ "${{ github.event_name == 'scheduled' }}" == "true" ]]; then
+          if [[ "${{ github.ref == 'refs/heads/master' }}" == "true" ]]; then
             echo ::set-output name=HAMLET_ENGINE::"unicycle"
-          else
-            echo ::set-output name=HAMLET_ENGINE::""
+            exit 0
           fi
+
+          if [[ "${{ github.event_name == 'scheduled' }}" == "true" ]]; then
+            echo ::set-output name=HAMLET_ENGINE::"tram"
+            exit 0
+          fi
+
+          echo ::set-output name=HAMLET_ENGINE::""
 
       - name: Push Release
         uses: docker/build-push-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           images: hamletio/hamlet
           flavor: |
             latest=auto
-            suffix=${{ matrix.suffix }}
+            suffix=${{ matrix.suffix }},onlatest=true
           tags: |
             type=edge,branch=master
             type=semver,pattern={{version}}

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ USER root
 # Apply some global envs to how hamlet should behave
 ENV HAMLET_ENGINE_INSTALL_UPDATE="true"
 
+ARG HAMLET_ENGINE
+ENV HAMLET_ENGINE=$HAMLET_ENGINE
+
 # Basic Package installs
 RUN apt-get update && apt-get install --no-install-recommends -y \
         # setup apt for different sources


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)

## Description

Use the scheduled builds to create a daily latest docker image that can be used in deployments that don't use the hamlet commands

## Motivation and Context

To cater for existing implementations we need a docker image that contains the latest hamlet release without the use of the hamlet cli. The nightly build of the docker image will default to use the unicycle engine by default and create a latest build each night.

## How Has This Been Tested?

Will be tested in CI process

## Related Changes


### Prerequisite PRs:
- None

### Dependent PRs:
- None

### Consumer Actions:

- None

