### PR TITLE
fix: match npm version to node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+        if: ${{ github.event_name == 'scheduled' || startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/master' }}
 
       - name: Hamlet engine
         id: hamlet_engine

--- a/scripts/user_env/0_nodenv.sh
+++ b/scripts/user_env/0_nodenv.sh
@@ -12,8 +12,8 @@ git clone --depth 1 https://github.com/nodenv/nodenv-default-packages.git "${NOD
 
 ( cd ${NODENV_ROOT} && src/configure && make -C src )
 
-# install package managers in all nodenv versions
-echo "npm" >> "${NODENV_ROOT}/default-packages"
+# Install yarn package manager in all nodenv versions
+# Leave npm version aligned with version of node
 echo "yarn" >> "${NODENV_ROOT}/default-packages"
 
 # nodenv install
@@ -21,6 +21,10 @@ NODE_VERSION=12.22.1
 eval "$(nodenv init -)"
 nodenv install "${NODE_VERSION}"
 nodenv global "${NODE_VERSION}"
-node --version
 
 nodenv package-hooks install --all
+
+# Show installed versions
+echo "node version = $(node --version)"
+echo "npm version = $(npm --version)"
+echo "yarn version = $(yarn --version)"


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Rely on the version of npm provided by node rather than always installing the latest.

Display more version information during the build.

## Motivation and Context
This permits configurations a more deterministic expectation as to when they need to upgrade to new major versions of npm, such as upgrades to `package-lock.json` files.

## How Has This Been Tested?
Tested when PR submitted

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

