### PR TITLE
fix: ignore meteor certificate issues

### DIFF
--- a/scripts/meteor/setup_meteor.sh
+++ b/scripts/meteor/setup_meteor.sh
@@ -3,6 +3,10 @@ set -euo pipefail
 
 METEOR_RELEASE="${METEOR_RELEASE:-"1.8.0.1"}"
 
+# Workaround for expired certificate with 1.8
+# https://docs.meteor.com/expired-certificate.html
+export NODE_TLS_REJECT_UNAUTHORIZED=0
+
 #Install Meteor
 curl https://install.meteor.com/?release=${METEOR_RELEASE} | sh
 


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Set environment variables to ignore certificate expiry issues when running meteor.

## Motivation and Context
Fixes #67 

Because we are building an old version of meteor, it is necessary to turn off some certificate checking during container build.

## How Has This Been Tested?
Tested as part of build process

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

