### PR TITLE
fix: relax the set commands used in bash scripts

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -e
 
 # Set the shim environment variables
 . /opt/tools/scripts/shim_setup.sh

--- a/scripts/jenkins-jnlp-agent/jenkins-agent
+++ b/scripts/jenkins-jnlp-agent/jenkins-agent
@@ -40,7 +40,7 @@
 . /opt/tools/scripts/shim_setup.sh
 
 # Allows for running extra startup commands
-if [ -n "${STARTUP_COMMANDS}" ]; then
+if [ -n "${STARTUP_COMMANDS:-}" ]; then
 	echo "Running extra startup commands...."
 	/usr/bin/env sh -c "${STARTUP_COMMANDS}"
 fi

--- a/scripts/shim_setup.sh
+++ b/scripts/shim_setup.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 # Set the appropriate shim mode for the engine you are working with
 HAMLET_ENGINE_SHIM_MODE="${HAMLET_ENGINE_SHIM_MODE:-"bundled"}"

--- a/scripts/user_env/0_pyenv.sh
+++ b/scripts/user_env/0_pyenv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 PYENV_ROOT="${PYENV_ROOT:-"${HOME}/.pyenv"}"
 

--- a/scripts/user_env/0_rbenv.sh
+++ b/scripts/user_env/0_rbenv.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 RBENV_ROOT="${RBENV_ROOT:-"${HOME}/.rbenv"}"
 


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)

## Description
<!--- Describe your changes in detail -->
- remove some of the set flags for exception handling

## Motivation and Context
<!--- Why make this change? Link to any existing issues here -->
Overly configured set commands were causing issues with container startup and executing scripts that were not built for the configuration

## How Has This Been Tested?
<!--- Include details of your testing environment, official tests or other methods -->
tested locally

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

